### PR TITLE
Special Characters in Bug

### DIFF
--- a/RestSrvr/OperationDispatcher.cs
+++ b/RestSrvr/OperationDispatcher.cs
@@ -41,7 +41,7 @@ namespace RestSrvr
         /// <summary>
         /// Represents the operation path regex
         /// </summary>
-        private readonly Regex m_templateParser = new Regex(@"([\w\{\}\*\.\-_]+)");
+        private readonly Regex m_templateParser = new Regex(@"([\$\/\\\:\#]|[\w\{\}\*\.\-_]+)");
 
         // Endpoint operation
         private EndpointOperation m_endpointOperation;
@@ -111,10 +111,14 @@ namespace RestSrvr
                         break;
                 }
 
-                regexBuilder.Append("/");
                 match = match.NextMatch();
             }
-            regexBuilder.Append("?$");
+            if (regexBuilder[1] == '/') // starting / is optional
+                regexBuilder.Insert(2, "?");
+            if (regexBuilder[regexBuilder.Length - 1] == '/') // ending with /? is optional
+                regexBuilder.Append("?");
+
+            regexBuilder.Append("$");
 
             this.m_regexGroupNames = this.m_regexGroupNames.Where(o => o != null).ToArray();
             this.m_traceSource.TraceEvent(TraceEventType.Verbose, 0, "Operation {0} will be bound to {1}", endpointOperation.Description.InvokeMethod, regexBuilder);

--- a/RestSrvr/RestSrvr.csproj
+++ b/RestSrvr/RestSrvr.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <PackageId>RestSrvr</PackageId>
     <Title>RestSrvr</Title>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <Description>The RestSrvr library represents a wrapper around .NET's HTTP API to provide a Windows Communication Foundation (WCF) REST like wrapper allowing for cross platform REST Server implementation used by the rest of SanteDB (Linux, Android, IOS, Windows, etc.)</Description>
     <Authors>SanteSuite Contributors</Authors>
     <PackageTags>SanteDB</PackageTags>

--- a/TestServer/Properties/AssemblyInfo.cs
+++ b/TestServer/Properties/AssemblyInfo.cs
@@ -49,6 +49,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("2.1.0*")]
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+// [assembly: AssemblyVersion("2.1.1*")]
+[assembly: AssemblyVersion("2.1.1.0")]
+[assembly: AssemblyFileVersion("2.1.1.0")]


### PR DESCRIPTION
There was an issue on the dispatcher where the endpoint/operation dispatcher wouldn't work on cases such as:

```
[RestInvoke(UriTemplate = "/Foo/${bar}")]
public void Foo(String bar);
```

This fixes this. Because this is a change in the foundational classes testing with all synchronization interfaces need to be performed.